### PR TITLE
refactor: remove cwvInterpolationFN, simpleCWVInterploationFN,  INTERPOLATION_THRESHOLD from utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,6 @@ import {
   reclassifyAcquisition,
   reclassifyEnter,
   addCalculatedProps,
-  cwvInterpolationFn,
-  simpleCWVInterpolationFn,
-  INTERPOLATION_THRESHOLD,
 } from './utils.js';
 
 const utils = {
@@ -51,9 +48,6 @@ const utils = {
   reclassifyAcquisition,
   reclassifyEnter,
   addCalculatedProps,
-  cwvInterpolationFn,
-  simpleCWVInterpolationFn,
-  INTERPOLATION_THRESHOLD,
 };
 const stats = {
   zTestTwoProportions,

--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ import {
   reclassifyAcquisition,
   reclassifyEnter,
   addCalculatedProps,
+  cwvInterpolationFn,
+  simpleCWVInterpolationFn,
+  INTERPOLATION_THRESHOLD,
 } from './utils.js';
 
 const utils = {
@@ -48,6 +51,9 @@ const utils = {
   reclassifyAcquisition,
   reclassifyEnter,
   addCalculatedProps,
+  cwvInterpolationFn,
+  simpleCWVInterpolationFn,
+  INTERPOLATION_THRESHOLD,
 };
 const stats = {
   zTestTwoProportions,
@@ -69,4 +75,6 @@ const series = {
   engagement,
 };
 
-export { DataChunks, utils, stats, series };
+export {
+  DataChunks, utils, stats, series,
+};

--- a/utils.js
+++ b/utils.js
@@ -172,38 +172,6 @@ export function scoreBundle(bundle) {
   return 'poor';
 }
 
-export const INTERPOLATION_THRESHOLD = 10;
-
-export function simpleCWVInterpolationFn(metric, threshold) {
-  return (cwvs) => {
-    const valuedWeights = Object.values(cwvs)
-      .filter((value) => value.weight !== undefined)
-      .map((value) => value.weight)
-      .reduce((acc, value) => acc + value, 0);
-    return cwvs[threshold + metric].weight / valuedWeights;
-  };
-}
-export function cwvInterpolationFn(targetMetric) {
-  return (cwvs) => {
-    const valueCount = cwvs.goodCWV.count + cwvs.niCWV.count + cwvs.poorCWV.count;
-    const valuedWeights = cwvs.goodCWV.weight + cwvs.niCWV.weight + cwvs.poorCWV.weight;
-
-    if (valueCount < INTERPOLATION_THRESHOLD) {
-      // not enough data to interpolate
-      return 0;
-    }
-    // total weight
-    const totalWeight = cwvs.goodCWV.weight
-      + cwvs.niCWV.weight
-      + cwvs.poorCWV.weight
-      + cwvs.noCWV.weight;
-    // share of targetMetric compared to all CWV
-    const share = cwvs[targetMetric].weight / (valuedWeights);
-    // interpolate the share to the total weight
-    return Math.round(share * totalWeight);
-  };
-}
-
 /**
  * Conversion rates are computed as the ratio of conversions to visits. The conversion rate is
  * capped at 100%.


### PR DESCRIPTION
The oversight ui currently uses cwvInterpolationFN, simpleCWVInterploationFN, and INTERPOLATION_THRESHOLD. The question is if we want to export them form utils. @trieloff, wdyt?