### PR TITLE
feat(series): redefine page views so that prerenders (that never are turned into navigation events) are no longer counted

### DIFF
--- a/series.js
+++ b/series.js
@@ -34,7 +34,7 @@ export const pageViews = (bundle) => {
   );
   const isPrerenderThenNavigate = bundle.events.find((evt) =>
     evt.checkpoint === 'navigate'
-    && evt.target === 'prerender');
+    && evt.target === 'prerendered');
   return isBundle && (!isPrerender || isPrerenderThenNavigate) ? bundle.weight : 0;
 };
 

--- a/series.js
+++ b/series.js
@@ -27,7 +27,16 @@ import { reclassifyAcquisition } from './utils.js';
  * @param {Bundle} bundle a series of events that belong to the same page view
  * @returns {number} the number of page views
  */
-export const pageViews = (bundle) => bundle.weight;
+export const pageViews = (bundle) => {
+  const isBundle = true;
+  const isPrerender = bundle.events.find((evt) =>
+    evt.checkpoint === 'prerender'
+  );
+  const isPrerenderThenNavigate = bundle.events.find((evt) =>
+    evt.checkpoint === 'navigate'
+    && evt.target === 'prerender');
+  return isBundle && (!isPrerender || isPrerenderThenNavigate) ? bundle.weight : 0;
+};
 
 /**
  * A visit is a page view that does not follow an internal link. This means a visit starts

--- a/test/series.test.js
+++ b/test/series.test.js
@@ -20,7 +20,10 @@ import {
 
 describe('series:pageViews', () => {
   it('pageViews:bare', () => {
-    assert.equal(pageViews({ weight: 1 }), 1);
+    assert.equal(pageViews({ weight: 1, events: [] }), 1);
+    assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'prerender' }] }), 0);
+    assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'navigate', target: 'prerender' }] }), 1);
+    assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'prerender' }, { checkpoint: 'navigate', target: 'prerender' }] }), 1);
   });
 
   it('pageViews:DataChunks', () => {

--- a/test/series.test.js
+++ b/test/series.test.js
@@ -23,7 +23,7 @@ describe('series:pageViews', () => {
     assert.equal(pageViews({ weight: 1, events: [] }), 1);
     assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'prerender' }] }), 0);
     assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'navigate', target: 'prerender' }] }), 1);
-    assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'prerender' }, { checkpoint: 'navigate', target: 'prerender' }] }), 1);
+    assert.equal(pageViews({ weight: 1, events: [{ checkpoint: 'prerender' }, { checkpoint: 'navigate', target: 'prerendered' }] }), 1);
   });
 
   it('pageViews:DataChunks', () => {


### PR DESCRIPTION
This PR goes hand in hand with https://github.com/adobe/helix-rum-enhancer/pull/301 and implements the rules outlined in https://github.com/adobe/helix-rum-enhancer/pull/301#issuecomment-2413365406
> - each bundle represents one page view
>   - unless there is a `prerender` checkpoint present, then it's not a page view
>     - unless there is also a `navigate.target=prerendered` checkpoint present, then it is a page view again