### PR TITLE
Classify Referrers

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,6 +15,17 @@ each series can be registered with a name using <code>DataChunks.addSeries(name,
 <dd></dd>
 </dl>
 
+## Constants
+
+<dl>
+<dt><a href="#facets">facets</a></dt>
+<dd></dd>
+<dt><a href="#facetFns">facetFns</a></dt>
+<dd><p>A collection of facet factory functions. Each function takes one or more
+parameters and returns a facet function according to the parameters.</p>
+</dd>
+</dl>
+
 ## Functions
 
 <dl>
@@ -112,6 +123,9 @@ capped at 100%.</p>
 <dt><a href="#Totals">Totals</a> ⇐ <code>Object&lt;string,</code></dt>
 <dd><p>A total is an object that contains {Metric} objects
 for each defined series.</p>
+</dd>
+<dt><a href="#FacetFn">FacetFn</a> ⇒ <code>Array.&lt;string&gt;</code></dt>
+<dd><p>A facet function takes a bundle and returns an array of facet values.</p>
 </dd>
 <dt><a href="#Line">Line</a> : <code>Object</code></dt>
 <dd></dd>
@@ -471,6 +485,184 @@ and each vaule is an array of bundles
 | --- | --- | --- |
 | groupByFn | [<code>groupByFn</code>](#groupByFn) | for each object, determine the group key |
 
+<a name="facets"></a>
+
+## facets
+**Kind**: global constant  
+**Import**: [<code>Bundle</code>](#Bundle) from './distiller.js'  
+
+* [facets](#facets)
+    * [.userAgent(bundle)](#facets.userAgent) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.url(bundle)](#facets.url) ⇒ <code>string</code>
+    * [.checkpoint(bundle)](#facets.checkpoint) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.vitals(bundle)](#facets.vitals) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.lcpTarget(bundle)](#facets.lcpTarget) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.lcpSource(bundle)](#facets.lcpSource) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.acquisitionSource(bundle)](#facets.acquisitionSource) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.enterSource(bundle)](#facets.enterSource) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.mediaTarget(bundle)](#facets.mediaTarget) ⇒ <code>Array.&lt;string&gt;</code>
+
+<a name="facets.userAgent"></a>
+
+### facets.userAgent(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Extracts each of device type and operating system from
+the simplified user agent string.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of device types and operating systems  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.url"></a>
+
+### facets.url(bundle) ⇒ <code>string</code>
+Extracts the path from the URL and removes potential PII such as
+ids, hashes, and other encoded data.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>string</code> - the path of the URL  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.checkpoint"></a>
+
+### facets.checkpoint(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Extracts the checkpoints from the bundle. Each checkpoint
+that occurs at least once in the bundle is returned as a facet
+value.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of checkpoints  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.vitals"></a>
+
+### facets.vitals(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Classifies the bundle according to the Core Web Vitals metrics.
+For each metric in `LCP`, `CLS`, and `INP`, the score is calculated
+as `good`, `needs improvement`, or `poor`.
+The result is a list of the form `[goodLCP, niCLS, poorINP]`
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of CWV metrics  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.lcpTarget"></a>
+
+### facets.lcpTarget(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Extracts the target of the Largest Contentful Paint (LCP) event from the bundle.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of LCP targets  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.lcpSource"></a>
+
+### facets.lcpSource(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Extracts the source of the Largest Contentful Paint (LCP) event from the bundle.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of LCP sources  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.acquisitionSource"></a>
+
+### facets.acquisitionSource(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Extracts the acquisition source from the bundle. As acquisition sources
+can be strings like `paid:video:youtube`, each of `paid`, `paid:video`,
+and `paid:video:youtube` are returned as separate values.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of acquisition sources  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.enterSource"></a>
+
+### facets.enterSource(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Classifies the referrer page of the enter event.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of referrer classifications, following the pattern:
+- the original source URL
+- the type and vendor of the referrer, e.g. `search:google`
+- the type of the referrer, e.g. `search`
+- the vendor of the referrer, regardless of type, e.g. `*:google`  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facets.mediaTarget"></a>
+
+### facets.mediaTarget(bundle) ⇒ <code>Array.&lt;string&gt;</code>
+Extracts the target of the media view event from the bundle. This
+is typically the URL of an image or video, and the URL is stripped
+of query parameters, hash, user, and password.
+
+**Kind**: static method of [<code>facets</code>](#facets)  
+**Returns**: <code>Array.&lt;string&gt;</code> - a list of media targets  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | the bundle of sampled rum events |
+
+<a name="facetFns"></a>
+
+## facetFns
+A collection of facet factory functions. Each function takes one or more
+parameters and returns a facet function according to the parameters.
+
+**Kind**: global constant  
+
+* [facetFns](#facetFns)
+    * [.checkpointSource(cp)](#facetFns.checkpointSource) ⇒ [<code>FacetFn</code>](#FacetFn)
+    * [.checkpointTarget(cp)](#facetFns.checkpointTarget) ⇒ [<code>FacetFn</code>](#FacetFn)
+
+<a name="facetFns.checkpointSource"></a>
+
+### facetFns.checkpointSource(cp) ⇒ [<code>FacetFn</code>](#FacetFn)
+Returns a function that creates a facet function for the source of the given
+checkpoint.
+
+**Kind**: static method of [<code>facetFns</code>](#facetFns)  
+**Returns**: [<code>FacetFn</code>](#FacetFn) - - a facet function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cp | <code>string</code> | the checkpoint |
+
+<a name="facetFns.checkpointTarget"></a>
+
+### facetFns.checkpointTarget(cp) ⇒ [<code>FacetFn</code>](#FacetFn)
+Returns a function that creates a facet function for the target of the given
+checkpoint.
+
+**Kind**: static method of [<code>facetFns</code>](#facetFns)  
+**Returns**: [<code>FacetFn</code>](#FacetFn) - a facet function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| cp | <code>string</code> | the checkpoint |
+
 <a name="seriesValueFn"></a>
 
 ## seriesValueFn(bundle) ⇒ <code>number</code> \| <code>undefined</code>
@@ -783,6 +975,18 @@ for each defined series.
 
 **Kind**: global typedef  
 **Extends**: <code>Object&lt;string,</code>  
+<a name="FacetFn"></a>
+
+## FacetFn ⇒ <code>Array.&lt;string&gt;</code>
+A facet function takes a bundle and returns an array of facet values.
+
+**Kind**: global typedef  
+**Returns**: <code>Array.&lt;string&gt;</code> - Array of facet values  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| bundle | [<code>Bundle</code>](#Bundle) | The bundle to process |
+
 <a name="Line"></a>
 
 ## Line : <code>Object</code>

--- a/facets.js
+++ b/facets.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { reclassifyConsent, reclassifyAcquisition, scoreCWV } from './utils.js';
+import { classifyReferrer } from './referrer.js';
 /**
   * @import {Bundle} from './distiller.js'
   */
@@ -139,6 +140,29 @@ export const facets = {
         .filter((s) => s))
       .pop() || [],
   ),
+  /**
+   * Classifies the referrer page of the enter event.
+   * @param {Bundle} bundle the bundle of sampled rum events
+   * @returns {string[]} a list of referrer classifications, following the pattern:
+   * - the original source URL
+   * - the type and vendor of the referrer, e.g. `search:google`
+   * - the type of the referrer, e.g. `search`
+   * - the vendor of the referrer, regardless of type, e.g. `*:google`
+   */
+  enterSource: (bundle) => bundle.events
+    .filter((evt) => evt.checkpoint === 'enter')
+    .map((evt) => evt.source)
+    .filter((source) => source)
+    .map((source) => {
+      const referrerClass = classifyReferrer(source);
+      return referrerClass ? [
+        source,
+        `${referrerClass.type}:${referrerClass.vendor}`,
+        referrerClass.type,
+        `*:${referrerClass.vendor}`,
+      ] : source;
+    })
+    .flat(),
   /**
    * Extracts the target of the media view event from the bundle. This
    * is typically the URL of an image or video, and the URL is stripped

--- a/facets.js
+++ b/facets.js
@@ -188,6 +188,14 @@ export const facets = {
       return u.toString();
     }),
 };
+
+/**
+ * A facet function takes a bundle and returns an array of facet values.
+ * @typedef {function} FacetFn
+ * @param {Bundle} bundle The bundle to process
+ * @returns {string[]} Array of facet values
+ */
+
 /**
  * A collection of facet factory functions. Each function takes one or more
  * parameters and returns a facet function according to the parameters.
@@ -196,10 +204,8 @@ export const facetFns = {
   /**
    * Returns a function that creates a facet function for the source of the given
    * checkpoint.
-   * @param {string} cp the checkpoint
-  * @returns {
-  function(bundle: Bundle): string[]
-} a facet function
+   * @return {FacetFn} - a facet function
+   * @param {string} cp - the checkpoint
    */
   checkpointSource: (cp) => (bundle) => Array.from(
     bundle.events
@@ -215,7 +221,7 @@ export const facetFns = {
    * Returns a function that creates a facet function for the target of the given
    * checkpoint.
    * @param {string} cp the checkpoint
-   * @returns {function(bundle: Bundle): string[]} a facet function
+   * @returns {FacetFn} a facet function
    */
   checkpointTarget: (cp) => (bundle) => Array.from(
     bundle.events

--- a/referrer.js
+++ b/referrer.js
@@ -459,4 +459,4 @@ export function classifyReferrer(referrerURL) {
   const result = referrers.find(({ match }) => match.test(referrerURL));
   if (result) return new Referrer(result.type, result.vendor, referrerURL);
   return undefined;
-} 
+}

--- a/referrer.js
+++ b/referrer.js
@@ -454,7 +454,7 @@ class Referrer {
   }
 }
 
-export default function classifyReferrer(referrerURL) {
+export function classifyReferrer(referrerURL) {
   if (!referrerURL) return undefined;
   const result = referrers.find(({ match }) => match.test(referrerURL));
   if (result) return new Referrer(result.type, result.vendor, referrerURL);

--- a/referrer.js
+++ b/referrer.js
@@ -1,0 +1,462 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const referrers = [
+  // Search
+  {
+    type: 'search',
+    vendor: 'google',
+    match: /https?:\/\/((www\.)?google\.|lens\.google\.com)/,
+  },
+  {
+    type: 'search',
+    vendor: 'baidu',
+    match: /https?:\/\/(m\.|www\.)?baidu\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'bing',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?bing\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'duckduckgo',
+    match: /https?:\/\/(www\.)?duckduckgo\.com(\/.*)?/,
+  },
+  {
+    type: 'search',
+    vendor: 'yahoo',
+    match: /https?:\/\/([a-z]{2}\.)?search\.yahoo\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'yahoo',
+    match: /https?:\/\/(search\.)?yahoo\.co\.jp/,
+  },
+  {
+    type: 'search',
+    vendor: 'yandex',
+    match: /https?:\/\/(www\.)?yandex\./,
+  },
+  {
+    type: 'search',
+    vendor: 'ecosia',
+    match: /https?:\/\/(www\.)?ecosia\.org/,
+  },
+  {
+    type: 'search',
+    vendor: 'brave',
+    match: /https?:\/\/(www\.)?search\.brave\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'naver',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?(search\.|)?naver\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'daum',
+    match: /https?:\/\/search\.daum\.net/,
+  },
+  // Daum Search Mobile
+  {
+    type: 'search',
+    vendor: 'daum',
+    match: /https?:\/\/m\.search\.daum\.net/,
+  },
+  {
+    type: 'search',
+    vendor: 'startpage',
+    match: /https?:\/\/(www\.)?startpage\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'presearch',
+    match: /https?:\/\/(www\.)?presearch\.com/,
+  },
+  {
+    type: 'search',
+    vendor: 'seznam',
+    match: /https?:\/\/(www\.)?search\.seznam\.cz/,
+  },
+  {
+    type: 'search',
+    vendor: 'docomo',
+    match: /https?:\/\/(service\.)?smt\.docomo\.ne\.jp/,
+  },
+  {
+    type: 'search',
+    vendor: 'googleusercontent',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?googleusercontent\.com/,
+  },
+  // Social
+  {
+    type: 'social',
+    vendor: 'facebook',
+    match: /https?:\/\/(www\.)?(m\.|l\.|lm\.)?facebook\.com\//,
+  },
+  {
+    type: 'social',
+    vendor: 'instagram',
+    match: /https?:\/\/(www\.)?(l\.)?instagram\.com\//,
+  },
+  {
+    type: 'social',
+    vendor: 'linkedin',
+    match: /https?:\/\/(www\.)?linkedin\.com/,
+  },
+  {
+    type: 'social',
+    vendor: 'linkedin',
+    match: /https?:\/\/lnkd\.in/,
+  },
+  {
+    type: 'social',
+    vendor: 'tiktok',
+    match: /https?:\/\/(www\.)?tiktok\.com/,
+  },
+  {
+    type: 'social',
+    vendor: 'x',
+    match: /https?:\/\/(www\.)?(t\.co\/|x\.com)/,
+  },
+  {
+    type: 'social',
+    vendor: 'reddit',
+    match: /https?:\/\/(www\.)?(old\.|out\.)?reddit\.com/,
+  },
+  {
+    type: 'social',
+    vendor: 'pinterest',
+    match: /https?:\/\/(www\.)?pinterest\.com/,
+  },
+  {
+    type: 'social',
+    vendor: 'linktree',
+    match: /https?:\/\/(www\.)?linktr\.ee/,
+  },
+  {
+    type: 'social',
+    vendor: 'snapchat',
+    match: /https?:\/\/(www\.)?snapchat\.com/,
+  },
+  // Chat
+  {
+    type: 'chat',
+    vendor: 'microsoft',
+    match: /https?:\/\/(.*\.)?teams\.microsoft\.com/,
+  },
+  {
+    type: 'chat',
+    vendor: 'microsoft',
+    match: /https?:\/\/(.*\.)?teams\.cdn\.office\.net/,
+  },
+  {
+    type: 'chat',
+    vendor: 'snapchat',
+    match: /https?:\/\/(www\.)?snapchat\.com/,
+  },
+  // Video
+  {
+    type: 'video',
+    vendor: 'youtube',
+    match: /https?:\/\/(www\.)?(m\.)?youtube\.com/,
+  },
+  {
+    type: 'video',
+    vendor: 'dailymotion',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?dailymotion\.com/,
+  },
+  // Ads
+  {
+    type: 'ads',
+    vendor: 'google',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?doubleclick\.net/,
+  },
+  {
+    type: 'ads',
+    vendor: 'google', // Doubleclick
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?2mdn\.net/,
+  },
+  {
+    type: 'ads',
+    vendor: 'google',
+    match: /https?:\/\/googleads\.g\.doubleclick\.net/,
+  },
+  {
+    type: 'ads',
+    vendor: 'google',
+    match: /https?:\/\/syndicatedsearch\.goog/,
+  },
+  {
+    type: 'ads',
+    vendor: 'google',
+    match: /https?:\/\/(tpc\.)?googlesyndication\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'googleadservices',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?googleadservices\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'appnexus',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?adnxs\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'pangle',
+    match: /https?:\/\/(www\.)?(pangle-global\.io|pangleglobal\.com)/,
+  },
+  {
+    type: 'ads',
+    vendor: 'linkbux',
+    match: /https?:\/\/(www\.)?linkbux\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'taboola',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?taboola\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'taboola',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?taboolanews\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'outbrain',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?outbrain\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'amazon',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?amazon-adsystem\.com/,
+  },
+  {
+    type: 'ads',
+    vendor: 'google',
+    match: /https?:\/\/imasdk\.googleapis\.com/,
+  },
+  // Auth
+  {
+    type: 'auth',
+    vendor: 'google',
+    match: /https?:\/\/accounts\.google\.com/,
+  },
+  {
+    type: 'auth',
+    vendor: 'microsoft',
+    match: /https?:\/\/login\.microsoftonline\.com/,
+  },
+  {
+    type: 'auth',
+    vendor: 'apple',
+    match: /https?:\/\/appleid\.apple\.com/,
+  },
+  // Productivity
+  {
+    type: 'productivity',
+    vendor: 'google',
+    match: /https?:\/\/(docs|drive|sheets|classroom|sites)\.google\.com/,
+  },
+  {
+    type: 'productivity',
+    vendor: 'microsoft',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?(office\.com|officeapps\.live\.com|sharepoint\.com)/,
+  },
+  // News
+  {
+    type: 'news',
+    vendor: 'newsweek',
+    match: /https?:\/\/(www\.)?newsweek\.com/,
+  },
+  {
+    type: 'news',
+    vendor: 'google',
+    match: /https?:\/\/news\.google\.com/,
+  },
+  {
+    type: 'news',
+    vendor: 'yahoo',
+    match: /https?:\/\/news\.yahoo\.co\.jp/,
+  },
+  {
+    type: 'news',
+    vendor: 'msn',
+    match: /https?:\/\/(www\.)?msn\.com/,
+  },
+  // CDN
+  {
+    type: 'cdn',
+    vendor: 'akamai',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?akamaihd\.net/,
+  },
+  {
+    type: 'cdn',
+    vendor: 'googleusercontent',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?googleusercontent\.com/,
+  },
+  // Video
+  {
+    type: 'video',
+    vendor: 'dailymotion',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?dailymotion\.com/,
+  },
+  // Developer
+  {
+    type: 'developer',
+    vendor: 'github',
+    match: /https?:\/\/(www\.)?github\.com/,
+  },
+  {
+    type: 'developer',
+    vendor: 'localhost',
+    match: /http:\/\/localhost(:[0-9]+)?/,
+  },
+  // Security
+  {
+    type: 'security',
+    vendor: 'themediatrust',
+    match: /https?:\/\/connect\.themediatrust\.com/,
+  },
+  {
+    type: 'security',
+    vendor: 'bxss',
+    match: /https?:\/\/bxss\.me/,
+  },
+  // Education
+  {
+    type: 'education',
+    vendor: 'wikipedia',
+    match: /https?:\/\/([a-z]{2,3}\.)?(m\.)?wikipedia\.org/,
+  },
+  // AI
+  {
+    type: 'ai',
+    vendor: 'openai',
+    match: /https?:\/\/(www\.)?chatgpt\.com/,
+  },
+  {
+    type: 'ai',
+    vendor: 'openai',
+    match: /https?:\/\/chat\.openai\.com/,
+  },
+  {
+    type: 'ai',
+    vendor: 'perplexity',
+    match: /https?:\/\/(www\.)?perplexity\.ai/,
+  },
+  {
+    type: 'ai',
+    vendor: 'microsoft',
+    match: /https?:\/\/copilot\.microsoft\.com/,
+  },
+  {
+    type: 'ai',
+    vendor: 'google',
+    match: /https?:\/\/gemini\.google\.com/,
+  },
+  {
+    type: 'ai',
+    vendor: 'anthropic',
+    match: /https?:\/\/(www\.)?claude\.ai/,
+  },
+  // Email
+  {
+    type: 'email',
+    vendor: 'outlook',
+    match: /https?:\/\/(www\.)?(outlook\.live\.com|outlook\.com)/,
+  },
+  {
+    type: 'email',
+    vendor: 'google',
+    match: /https?:\/\/mail\.google\.com/,
+  },
+  {
+    type: 'email',
+    vendor: 'yahoo',
+    match: /https?:\/\/(mail|m\.mail)\.yahoo\.(com|co\.jp)/,
+  },
+
+  // Storage/CDN
+  {
+    type: 'cdn',
+    vendor: 'google',
+    match: /https?:\/\/storage\.googleapis\.com/,
+  },
+
+  // Ads
+  {
+    type: 'ads',
+    vendor: 'googleads',
+    match: /https?:\/\/([a-zA-Z0-9_-]+\.)?googlesyndication\.com/,
+  },
+
+  // Auth
+  {
+    type: 'auth',
+    vendor: 'apple',
+    match: /https?:\/\/appleid\.apple\.com/,
+  },
+
+  // Search (Additional Yahoo Domains)
+  {
+    type: 'search',
+    vendor: 'yahoo',
+    match: /https?:\/\/(www\.|m\.)?yahoo\.(com|co\.jp)/,
+  },
+
+  // Ads
+  {
+    type: 'ads',
+    vendor: 'pangle',
+    match: /https?:\/\/(www\.)?pangle-global\.io/,
+  },
+
+  // Messaging/Chat
+  {
+    type: 'chat',
+    vendor: 'telegram',
+    match: /https?:\/\/(www\.)?web\.telegram\.org/,
+  },
+
+  // URL Shorteners
+  {
+    type: 'social',
+    vendor: 'bitly',
+    match: /https?:\/\/(www\.)?bit\.ly/,
+  },
+
+  // Add this in the Ads section with other ad vendors
+  {
+    type: 'ads',
+    vendor: 'criteo',
+    match: /https?:\/\/ads\.(eu\.)?criteo\.com/,
+  },
+];
+
+class Referrer {
+  constructor(type, vendor, referrerURL) {
+    this.checkpoint = 'enter';
+    this.type = type;
+    this.vendor = vendor;
+    this.source = referrerURL;
+  }
+}
+
+export default function classifyReferrer(referrerURL) {
+  if (!referrerURL) return undefined;
+  const result = referrers.find(({ match }) => match.test(referrerURL));
+  if (result) return new Referrer(result.type, result.vendor, referrerURL);
+  return undefined;
+} 

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -165,6 +165,26 @@ describe('facets:acquisitionSource', () => {
   });
 });
 
+describe('facets:enterSource', () => {
+  it('enterSource:bare', () => {
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.example.com' }] }), ['https://www.example.com']);
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com' }] }), ['https://www.google.com', 'search:google', 'search', '*:google']);
+  });
+
+  it('enterSource:DataChunks', () => {
+    const d = new DataChunks();
+    d.load(testChunks);
+    d.addSeries('pageViews', pageViews);
+    d.addFacet('enterSource', facets.enterSource);
+
+    assert.equal(d.facets.enterSource.length, 46);
+    assert.equal(d.facets.enterSource[2].value, 'search'); // all search engines
+    assert.equal(d.facets.enterSource[3].value, 'search:google'); // google search
+    assert.equal(d.facets.enterSource[4].value, '*:google'); // all google properties
+    assert.equal(d.facets.enterSource[5].value, 'https://www.google.com/'); // that one specific google page
+  });
+});
+
 describe('facets:mediaTarget', () => {
   it('mediaTarget:bare', () => {
     assert.deepEqual(facets.mediaTarget(

--- a/test/referrer.test.js
+++ b/test/referrer.test.js
@@ -105,4 +105,4 @@ describe('classifyReferrer', () => {
   it('should return undefined for unclassified referrers', () => {
     assert.equal(classifyReferrer('https://unknown-domain.com'), undefined);
   });
-}); 
+});

--- a/test/referrer.test.js
+++ b/test/referrer.test.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import classifyReferrer from '../referrer.js';
+
+describe('classifyReferrer', () => {
+  const testCases = [
+    // Search Engines
+    { input: 'https://www.google.com/', expected: { type: 'search', vendor: 'google' } },
+    { input: 'https://www.bing.com/', expected: { type: 'search', vendor: 'bing' } },
+    { input: 'https://duckduckgo.com/', expected: { type: 'search', vendor: 'duckduckgo' } },
+    { input: 'https://search.yahoo.com/', expected: { type: 'search', vendor: 'yahoo' } },
+    { input: 'https://yandex.ru/', expected: { type: 'search', vendor: 'yandex' } },
+    { input: 'https://search.brave.com/', expected: { type: 'search', vendor: 'brave' } },
+    { input: 'https://www.ecosia.org/', expected: { type: 'search', vendor: 'ecosia' } },
+    { input: 'https://syndicatedsearch.goog/', expected: { type: 'ads', vendor: 'google' } },
+    { input: 'https://m.baidu.com/', expected: { type: 'search', vendor: 'baidu' } },
+    { input: 'https://naver.com/', expected: { type: 'search', vendor: 'naver' } },
+
+    // Social Media
+    { input: 'http://m.facebook.com/', expected: { type: 'social', vendor: 'facebook' } },
+    { input: 'https://l.facebook.com/', expected: { type: 'social', vendor: 'facebook' } },
+    { input: 'http://instagram.com/', expected: { type: 'social', vendor: 'instagram' } },
+    { input: 'https://l.instagram.com/', expected: { type: 'social', vendor: 'instagram' } },
+    { input: 'https://www.linkedin.com/', expected: { type: 'social', vendor: 'linkedin' } },
+    { input: 'https://out.reddit.com/', expected: { type: 'social', vendor: 'reddit' } },
+    { input: 'https://x.com/', expected: { type: 'social', vendor: 'x' } },
+
+    // Video Platforms
+    { input: 'https://youtube.com/', expected: { type: 'video', vendor: 'youtube' } },
+    { input: 'https://www.youtube.com/', expected: { type: 'video', vendor: 'youtube' } },
+    { input: 'https://www.dailymotion.com/', expected: { type: 'video', vendor: 'dailymotion' } },
+
+    // Advertising
+    { input: 'https://googleads.g.doubleclick.net/', expected: { type: 'ads', vendor: 'google' } },
+    { input: 'https://partner.googleadservices.com/', expected: { type: 'ads', vendor: 'googleadservices' } },
+    { input: 'https://ads.eu.criteo.com/', expected: { type: 'ads', vendor: 'criteo' } },
+    { input: 'https://www.pangleglobal.com/', expected: { type: 'ads', vendor: 'pangle' } },
+    { input: 'https://pangle-global.io/', expected: { type: 'ads', vendor: 'pangle' } },
+    { input: 'https://www.linkbux.com/', expected: { type: 'ads', vendor: 'linkbux' } },
+    { input: 'https://s0.2mdn.net/', expected: { type: 'ads', vendor: 'google' } },
+
+    // News
+    { input: 'https://news.google.com/', expected: { type: 'news', vendor: 'google' } },
+    { input: 'https://news.yahoo.co.jp/', expected: { type: 'news', vendor: 'yahoo' } },
+    { input: 'https://www.msn.com/', expected: { type: 'news', vendor: 'msn' } },
+
+    // Email
+    { input: 'https://mail.google.com/', expected: { type: 'email', vendor: 'google' } },
+    { input: 'https://mail.yahoo.com/', expected: { type: 'email', vendor: 'yahoo' } },
+
+    // Chat/Communication
+    { input: 'https://web.telegram.org/', expected: { type: 'chat', vendor: 'telegram' } },
+    { input: 'https://statics.teams.cdn.office.net/', expected: { type: 'chat', vendor: 'microsoft' } },
+
+    // AI
+    { input: 'https://chatgpt.com/', expected: { type: 'ai', vendor: 'openai' } },
+    { input: 'https://copilot.microsoft.com/', expected: { type: 'ai', vendor: 'microsoft' } },
+    { input: 'https://claude.ai/', expected: { type: 'ai', vendor: 'anthropic' } },
+
+    // Developer
+    { input: 'http://localhost:3000/', expected: { type: 'developer', vendor: 'localhost' } },
+    { input: 'http://localhost:4200/', expected: { type: 'developer', vendor: 'localhost' } },
+    { input: 'https://github.com/', expected: { type: 'developer', vendor: 'github' } },
+
+    // Education
+    { input: 'https://en.m.wikipedia.org/', expected: { type: 'education', vendor: 'wikipedia' } },
+    { input: 'https://fa.m.wikipedia.org/', expected: { type: 'education', vendor: 'wikipedia' } },
+    { input: 'https://ja.wikipedia.org/', expected: { type: 'education', vendor: 'wikipedia' } },
+
+    // URL Shorteners
+    { input: 'https://bit.ly/', expected: { type: 'social', vendor: 'bitly' } },
+    { input: 'https://lnkd.in/', expected: { type: 'social', vendor: 'linkedin' } },
+
+    // Security
+    { input: 'https://connect.themediatrust.com/', expected: { type: 'security', vendor: 'themediatrust' } },
+    { input: 'https://bxss.me/', expected: { type: 'security', vendor: 'bxss' } },
+  ];
+
+  testCases.forEach(({ input, expected }) => {
+    it(`should classify ${input} as ${expected.type}:${expected.vendor}`, () => {
+      const result = classifyReferrer(input);
+      assert.ok(result, `Failed to classify ${input}, expected ${expected.type}:${expected.vendor}`);
+      assert.equal(result.type, expected.type);
+      assert.equal(result.vendor, expected.vendor);
+    });
+  });
+
+  it('should return undefined for empty input', () => {
+    assert.equal(classifyReferrer(''), undefined);
+    assert.equal(classifyReferrer(null), undefined);
+    assert.equal(classifyReferrer(undefined), undefined);
+  });
+
+  it('should return undefined for unclassified referrers', () => {
+    assert.equal(classifyReferrer('https://unknown-domain.com'), undefined);
+  });
+}); 

--- a/test/referrer.test.js
+++ b/test/referrer.test.js
@@ -11,7 +11,7 @@
  */
 import assert from 'assert';
 import { describe, it } from 'node:test';
-import classifyReferrer from '../referrer.js';
+import { classifyReferrer } from '../referrer.js';
 
 describe('classifyReferrer', () => {
   const testCases = [


### PR DESCRIPTION
This adds a new facet `enterSource` which can be used for more
advanced referrer cassification. A referrer like `https://www.example.com`
will remain unchanged, but when the referrer is `https://www.google.com` following
additional facet values will be returned:
- `search` (as this is a search engine)
- `search:google` (as this is in fact Google Search)
- `*:google` (for all Google properties)
- `https://www.google.com/` (we also return the original value)

- feat(referrer): add referrer classification
- feat(facets): add enterSource facet, which is based on the referrer classification
- docs(API): add FacetFn to API.md, regenerate docs, document the new `enterSource` facet
- style(referrer): add line break at end of file
