### PR TITLE
fix: respect plainURL contract for domains

### DIFF
--- a/facets.js
+++ b/facets.js
@@ -54,6 +54,10 @@ export const facets = {
         if (segment.length > 35 && /^[0-9a-f-]+$/.test(segment)) {
           return '<uuid>';
         }
+        // just too long
+        if (segment.length > 60) {
+          return '...';
+        }
         return segment;
       }).join('/');
     return u.toString();

--- a/facets.js
+++ b/facets.js
@@ -54,10 +54,6 @@ export const facets = {
         if (segment.length > 35 && /^[0-9a-f-]+$/.test(segment)) {
           return '<uuid>';
         }
-        // just too long
-        if (segment.length > 60) {
-          return '...';
-        }
         return segment;
       }).join('/');
     return u.toString();

--- a/facets.js
+++ b/facets.js
@@ -59,6 +59,7 @@ export const facets = {
     return u.toString();
   },
   plainURL: (bundle) => {
+    if (bundle.domain) return bundle.domain;
     const u = new URL(bundle.url);
     u.search = '';
     u.hash = '';

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -49,8 +49,8 @@ describe('facets:url', () => {
     // uuid in path
     assert.equal(facets.url({ url: 'https://www.example.com/path/123e4567-e89b-12d3-a456-426614174000' }), `https://www.example.com/path/${encodeURIComponent('<uuid>')}`);
     // long path
-    assert.equal(facets.url({ url: 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz' }), 'https://www.example.com/path/...');
-    assert.equal(facets.url({ url: 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon' }), 'https://blog.adobe.com/en/publish/2024/09/11/...');
+    assert.equal(facets.url({ url: 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz' }), 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz');
+    assert.equal(facets.url({ url: 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon' }), 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon');
 
     assert.equal(facets.url({ domain: 'custom.domain' }), 'custom.domain');
   });

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -75,6 +75,37 @@ describe('facets:plainURL', () => {
     assert.equal(facets.plainURL({ url: 'https://www.example.com/user/12345' }), 'https://www.example.com/user/12345');
     assert.equal(facets.plainURL({ url: 'https://www.example.com/hash/a1b2c3d4e5f6' }), 'https://www.example.com/hash/a1b2c3d4e5f6');
     assert.equal(facets.plainURL({ url: 'https://www.example.com/path/to/page?query=string#fragment' }), 'https://www.example.com/path/to/page');
+    // base64 encoded data in path
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/path/VGVzdHMgYXJlIGtpbmRhIGltcG9ydGFudA==' }), 'https://www.example.com/path/VGVzdHMgYXJlIGtpbmRhIGltcG9ydGFudA==');
+    // uuid in path
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/path/123e4567-e89b-12d3-a456-426614174000' }), 'https://www.example.com/path/123e4567-e89b-12d3-a456-426614174000');
+    // long path
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz' }), 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz');
+    assert.equal(facets.plainURL({ url: 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon' }), 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon');
+
+    assert.equal(facets.plainURL({ domain: 'custom.domain' }), 'custom.domain');
+  });
+
+  it('plainURL:DataChunks', () => {
+    const d = new DataChunks();
+    d.load(testChunks);
+    d.addSeries('pageViews', pageViews);
+    d.addFacet('plainURL', facets.plainURL);
+
+    // Assert that we have facets for URL
+    assert.ok(d.facets.plainURL.length > 0);
+    assert.equal(d.facets.plainURL.length, 92);
+
+    assert.equal(d.facets.plainURL[0].value, 'https://www.aem.live/home');
+  });
+});
+
+describe('facets:plainURL', () => {
+  it('plainURL:bare', () => {
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/path/to/page' }), 'https://www.example.com/path/to/page');
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/user/12345' }), 'https://www.example.com/user/12345');
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/hash/a1b2c3d4e5f6' }), 'https://www.example.com/hash/a1b2c3d4e5f6');
+    assert.equal(facets.plainURL({ url: 'https://www.example.com/path/to/page?query=string#fragment' }), 'https://www.example.com/path/to/page');
     assert.equal(facets.plainURL({ url: 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon' }), 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon');
   });
 });

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -49,8 +49,8 @@ describe('facets:url', () => {
     // uuid in path
     assert.equal(facets.url({ url: 'https://www.example.com/path/123e4567-e89b-12d3-a456-426614174000' }), `https://www.example.com/path/${encodeURIComponent('<uuid>')}`);
     // long path
-    assert.equal(facets.url({ url: 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz' }), 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz');
-    assert.equal(facets.url({ url: 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon' }), 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon');
+    assert.equal(facets.url({ url: 'https://www.example.com/path/loremlipsumdolorsitametconsecteturadipiscingelit-1234567890-abcdefghijklmnopqrstuvwxyz' }), 'https://www.example.com/path/...');
+    assert.equal(facets.url({ url: 'https://blog.adobe.com/en/publish/2024/09/11/bringing-gen-ai-to-video-adobe-firefly-video-model-coming-soon' }), 'https://blog.adobe.com/en/publish/2024/09/11/...');
 
     assert.equal(facets.url({ domain: 'custom.domain' }), 'custom.domain');
   });


### PR DESCRIPTION
The `url` facet returns `domain` if presents in bundle. `plainURL` should respect the same contract.
+ added tests for `plainURL`.