### PR TITLE
fix: stack size exceeds for get bundles in nodejs

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -427,9 +427,24 @@ export class DataChunks {
    */
   get bundles() {
     if (!this.memo.bundles) {
-      this.memo.bundles = [];
-      for (const chunk of this.data) {
-        this.memo.bundles = this.memo.bundles.concat(chunk.rumBundles);
+      // Calculate total length of all rumBundles
+      let totalLength = 0;
+      for (let i = 0; i < this.data.length; i += 1) {
+        totalLength += this.data[i].rumBundles.length;
+      }
+
+      // Preallocate the array
+      this.memo.bundles = new Array(totalLength);
+
+      // Fill the preallocated array
+      let index = 0;
+      for (let i = 0; i < this.data.length; i += 1) {
+        // eslint-disable-next-line prefer-destructuring
+        const rumBundles = this.data[i].rumBundles;
+        for (let j = 0; j < rumBundles.length; j += 1) {
+          this.memo.bundles[index] = rumBundles[j];
+          index += 1;
+        }
       }
     }
     return this.memo.bundles;

--- a/distiller.js
+++ b/distiller.js
@@ -426,11 +426,12 @@ export class DataChunks {
    * @returns {Bundle[]} all bundles, regardless of the chunk they belong to
    */
   get bundles() {
-    if (this.memo.bundles) return this.memo.bundles;
-    this.memo.bundles = this.data.reduce((acc, chunk) => {
-      acc.push(...chunk.rumBundles);
-      return acc;
-    }, []);
+    if (!this.memo.bundles) {
+      this.memo.bundles = [];
+      for (const chunk of this.data) {
+        this.memo.bundles = this.memo.bundles.concat(chunk.rumBundles);
+      }
+    }
     return this.memo.bundles;
   }
 


### PR DESCRIPTION
The array destructuring in the get bundles method causing `RangeError: Maximum call stack size exceeded` in NodeJS environments with default stack size when working with high number of bundles (ie. hourly adobe.com RUM bundles for 3 days)

This PR introduces highly optimized yet slightly less-readable version for that specific piece of code.

Here is the observed error:

```
RangeError: Maximum call stack size exceeded
    at file:///Users/username/WebstormProjects/spacecat-shared/node_modules/@adobe/rum-distiller/distiller.js:431:11
    at Array.reduce (<anonymous>)
    at get bundles [as bundles] (file:///Users/username/WebstormProjects/spacecat-shared/node_modules/@adobe/rum-distiller/distiller.js:430:35)
    at file:///Users/username/WebstormProjects/spacecat-shared/node_modules/@adobe/rum-distiller/distiller.js:789:18
    at Array.reduce (<anonymous>)
    at get facets [as facets] (file:///Users/username/WebstormProjects/spacecat-shared/node_modules/@adobe/rum-distiller/distiller.js:769:8)
    at Object.handler (file:///Users/username/WebstormProjects/spacecat-shared/packages/spacecat-shared-rum-api-client/src/functions/cwv.js:34:29)
    at file:///Users/username/WebstormProjects/spacecat-shared/packages/spacecat-shared-rum-api-client/src/one-off/revolt.js:27:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.15.1

```

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
