### PR TITLE
feat: normalise # in URLs for referrer classification

### DIFF
--- a/facets.js
+++ b/facets.js
@@ -159,13 +159,14 @@ export const facets = {
     .map((evt) => evt.source)
     .filter((source) => source)
     .map((source) => {
-      const referrerClass = classifyReferrer(source);
+      const normalizedSource = source.replace(/\#$/, '');
+      const referrerClass = classifyReferrer(normalizedSource);
       return referrerClass ? [
-        source,
+        normalizedSource,
         `${referrerClass.type}:${referrerClass.vendor}`,
         referrerClass.type,
         `*:${referrerClass.vendor}`,
-      ] : source;
+      ] : normalizedSource;
     })
     .flat(),
   /**

--- a/facets.js
+++ b/facets.js
@@ -154,21 +154,26 @@ export const facets = {
    * - the type of the referrer, e.g. `search`
    * - the vendor of the referrer, regardless of type, e.g. `*:google`
    */
-  enterSource: (bundle) => bundle.events
-    .filter((evt) => evt.checkpoint === 'enter')
-    .map((evt) => evt.source)
-    .filter((source) => source)
-    .map((source) => {
-      const normalizedSource = source.replace(/\#$/, '');
-      const referrerClass = classifyReferrer(normalizedSource);
-      return referrerClass ? [
-        normalizedSource,
-        `${referrerClass.type}:${referrerClass.vendor}`,
-        referrerClass.type,
-        `*:${referrerClass.vendor}`,
-      ] : normalizedSource;
-    })
-    .flat(),
+  enterSource: (bundle) => {
+    const normalizedSources = bundle.events
+      .filter((evt) => evt.checkpoint === 'enter')
+      .map((evt) => evt.source)
+      .filter((source) => source)
+      .map((source) => {
+        const normalizedSource = source.replace(/\/#$/, '');
+        const referrerClass = classifyReferrer(normalizedSource);
+        return referrerClass ? [
+          normalizedSource,
+          `${referrerClass.type}:${referrerClass.vendor}`,
+          referrerClass.type,
+          `*:${referrerClass.vendor}`,
+        ] : normalizedSource;
+      })
+      .flat();
+    
+    const uniqueSources = new Set(normalizedSources);
+    return uniqueSources;
+  },
   /**
    * Extracts the target of the media view event from the bundle. This
    * is typically the URL of an image or video, and the URL is stripped
@@ -193,7 +198,7 @@ export const facets = {
       }
       return u.toString();
     }),
-};
+  };
 
 /**
  * A facet function takes a bundle and returns an array of facet values.

--- a/facets.js
+++ b/facets.js
@@ -154,26 +154,21 @@ export const facets = {
    * - the type of the referrer, e.g. `search`
    * - the vendor of the referrer, regardless of type, e.g. `*:google`
    */
-  enterSource: (bundle) => {
-    const normalizedSources = bundle.events
-      .filter((evt) => evt.checkpoint === 'enter')
-      .map((evt) => evt.source)
-      .filter((source) => source)
-      .map((source) => {
-        const normalizedSource = source.replace(/\/#$/, '');
-        const referrerClass = classifyReferrer(normalizedSource);
-        return referrerClass ? [
-          normalizedSource,
-          `${referrerClass.type}:${referrerClass.vendor}`,
-          referrerClass.type,
-          `*:${referrerClass.vendor}`,
-        ] : normalizedSource;
-      })
-      .flat();
-    
-    const uniqueSources = new Set(normalizedSources);
-    return uniqueSources;
-  },
+  enterSource: (bundle) => bundle.events
+    .filter((evt) => evt.checkpoint === 'enter')
+    .map((evt) => evt.source)
+    .filter((source) => source)
+    .map((source) => source.replace(/\/#$/, ''))
+    .map((source) => {
+      const referrerClass = classifyReferrer(source);
+      return referrerClass ? [
+        source,
+        `${referrerClass.type}:${referrerClass.vendor}`,
+        referrerClass.type,
+        `*:${referrerClass.vendor}`,
+      ] : source;
+    })
+    .flat(),
   /**
    * Extracts the target of the media view event from the bundle. This
    * is typically the URL of an image or video, and the URL is stripped

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -216,6 +216,11 @@ describe('facets:enterSource', () => {
     assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com' }] }), ['https://www.google.com', 'search:google', 'search', '*:google']);
   });
 
+  it('enterSource:normalizeUrl', () => {
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.example.com/#' }] }), ['https://www.example.com']);
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com/#' }] }), ['https://www.google.com', 'search:google', 'search', '*:google']);
+  });
+
   it('enterSource:DataChunks', () => {
     const d = new DataChunks();
     d.load(testChunks);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR handles normalizing `#` in URLs for referrer classification 

## Related Issue
#31 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
