### PR TITLE
Optimized Normalization of # in URLs for referrer classification

### DIFF
--- a/facets.js
+++ b/facets.js
@@ -158,7 +158,18 @@ export const facets = {
     .filter((evt) => evt.checkpoint === 'enter')
     .map((evt) => evt.source)
     .filter((source) => source)
-    .map((source) => source.replace(/\/#$/, ''))
+    .map((source) => {
+      try {
+        const url = new URL(source);
+        url.hash = ''; // Remove the hash
+        return url.href;
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(`Invalid URL: ${source}`);
+        return null;
+      }
+    })
+    .filter((source) => source)
     .map((source) => {
       const referrerClass = classifyReferrer(source);
       return referrerClass ? [
@@ -169,6 +180,7 @@ export const facets = {
       ] : source;
     })
     .flat(),
+
   /**
    * Extracts the target of the media view event from the bundle. This
    * is typically the URL of an image or video, and the URL is stripped

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -212,13 +212,13 @@ describe('facets:acquisitionSource', () => {
 
 describe('facets:enterSource', () => {
   it('enterSource:bare', () => {
-    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.example.com' }] }), ['https://www.example.com']);
-    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com' }] }), ['https://www.google.com', 'search:google', 'search', '*:google']);
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.example.com/' }] }), ['https://www.example.com/']);
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com/' }] }), ['https://www.google.com/', 'search:google', 'search', '*:google']);
   });
 
   it('enterSource:normalizeUrl', () => {
-    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.example.com/#' }] }), ['https://www.example.com']);
-    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com/#' }] }), ['https://www.google.com', 'search:google', 'search', '*:google']);
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.example.com/#' }] }), ['https://www.example.com/']);
+    assert.deepEqual(facets.enterSource({ events: [{ checkpoint: 'enter', source: 'https://www.google.com/#' }] }), ['https://www.google.com/', 'search:google', 'search', '*:google']);
   });
 
   it('enterSource:DataChunks', () => {
@@ -227,11 +227,12 @@ describe('facets:enterSource', () => {
     d.addSeries('pageViews', pageViews);
     d.addFacet('enterSource', facets.enterSource);
 
-    assert.equal(d.facets.enterSource.length, 46);
-    assert.equal(d.facets.enterSource[2].value, 'search'); // all search engines
-    assert.equal(d.facets.enterSource[3].value, 'search:google'); // google search
-    assert.equal(d.facets.enterSource[4].value, '*:google'); // all google properties
-    assert.equal(d.facets.enterSource[5].value, 'https://www.google.com/'); // that one specific google page
+    assert.equal(d.facets.enterSource.length, 44);
+
+    assert.equal(d.facets.enterSource[0].value, 'search'); // all search engines
+    assert.equal(d.facets.enterSource[1].value, 'search:google'); // google search
+    assert.equal(d.facets.enterSource[2].value, '*:google'); // all google properties
+    assert.equal(d.facets.enterSource[3].value, 'https://www.google.com/'); // that one specific google page
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds an optimized way of normalizing # in URLs for referrer classification and also adds test coverage for the same.

## Related Issue
#34 

## Motivation and Context
Fixes the workaround of normalizing # in URLs

## How Has This Been Tested?
Test case is added for the same.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
