### PR TITLE
Fix Cluster Facet

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -435,7 +435,7 @@ export class DataChunks {
     this.addFacet(facetName, (bundle) => {
       const facetMatch = facetValues.find((f) => f.entries.some((e) => e.id === bundle.id));
       const clusters = producer(facetMatch.value);
-      return [facetMatch, ...clusters.filter((cluster) => sortedClusters.includes(cluster))];
+      return [facetMatch.value, ...clusters.filter((cluster) => sortedClusters.includes(cluster))];
     });
   }
 

--- a/test/distiller.test.js
+++ b/test/distiller.test.js
@@ -945,6 +945,10 @@ describe('DataChunks.addClusterFacet()', () => {
     const { facets } = d;
 
     assert.ok(facets.urlCluster.length > 0);
+    assert.notEqual(facets.urlCluster[0].value, '[object Object]');
+    assert.equal(facets.urlCluster[0].value, '/developer');
+    assert.equal(facets.urlCluster[1].value, 'https://www.aem.live/home');
+    assert.equal(facets.urlCluster[2].value, 'https://www.aem.live/developer/tutorial');
   });
 
   it('should handle empty facet values gracefully', () => {


### PR DESCRIPTION
The cluster facet would return the first facet as `[object Object]` and then only the cluster values,
but never the unclustered values. This PR validates the results of the cluster facet and fixes the
production of unclustered values
