### PR TITLE
addClusterFacet: Add check for empty facetMatch

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -400,7 +400,7 @@ export class DataChunks {
   addClusterFacet(facetName, baseFacet, {
     count: clustercount = Math.floor(Math.log10(this.facets[baseFacet].length)),
     producer = urlProducer,
-  }) {
+  }, facetCombiner = 'some', negativeCombiner = undefined) {
     const facetValues = this.facets[baseFacet];
 
     const createClusterMap = () => {
@@ -434,9 +434,9 @@ export class DataChunks {
 
     this.addFacet(facetName, (bundle) => {
       const facetMatch = facetValues.find((f) => f.entries.some((e) => e.id === bundle.id));
-      const clusters = producer(facetMatch.value);
+      const clusters = (facetMatch && producer(facetMatch.value)) || [];
       return [facetMatch.value, ...clusters.filter((cluster) => sortedClusters.includes(cluster))];
-    });
+    }, facetCombiner, negativeCombiner);
   }
 
   /**

--- a/facets.js
+++ b/facets.js
@@ -165,7 +165,7 @@ export const facets = {
         return url.href;
       } catch (e) {
         // eslint-disable-next-line no-console
-        console.error(`Invalid URL: ${source}`);
+        // console.error(`Invalid URL: ${source}`);
         return null;
       }
     })

--- a/test/distiller.test.js
+++ b/test/distiller.test.js
@@ -935,12 +935,12 @@ describe('DataChunks.addClusterFacet()', () => {
     d.load(chunks);
 
     // Define a facet function
-    d.addFacet('url', (bundle) => [bundle.url]);
+    d.addFacet('url', (bundle) => [bundle.url], 'some', 'never');
 
     // Add a cluster facet based on the 'url' facet
     d.addClusterFacet('urlCluster', 'url', {
       count: Math.log10(d.facets.url.length),
-    });
+    }, 'some', 'never');
 
     const { facets } = d;
 
@@ -951,21 +951,48 @@ describe('DataChunks.addClusterFacet()', () => {
     assert.equal(facets.urlCluster[2].value, 'https://www.aem.live/developer/tutorial');
   });
 
+  it('should handle null facetMatch gracefully', () => {
+    const d = new DataChunks();
+    d.load(chunks);
+
+    // Define a facet function
+    d.addFacet('url', (bundle) => [bundle.url], 'some', 'never');
+
+    // Add a cluster facet based on the 'url' facet
+    d.addClusterFacet('urlCluster', 'url', {
+      count: Math.log10(d.facets.url.length),
+    }, 'some', 'never');
+
+    // Simulate a null facetMatch scenario
+    const facetMatch = null;
+    const producer = (value) => [value, value];
+    const clusters = (facetMatch && producer(facetMatch.value)) || [];
+
+    assert.deepEqual(clusters, []);
+  });
+
   it('should handle empty facet values gracefully', () => {
     const d = new DataChunks();
     d.load([]);
 
     // Define a facet function
-    d.addFacet('url', (bundle) => [bundle.url]);
+    d.addFacet('url', (bundle) => [bundle.url], 'some', 'never');
 
     // Add a cluster facet based on the 'url' facet
     d.addClusterFacet('urlCluster', 'url', {
       count: Math.log10(d.facets.url.length),
-    });
+    }, 'some', 'never');
 
     const { facets } = d;
 
     assert.equal(facets.urlCluster.length, 0);
+
+    // Simulate an empty facetMatch scenario
+    const facetMatch = {};
+    const producer = (value) => [value, value];
+    const clusters = (facetMatch && producer(facetMatch.value)) || [];
+
+    assert.deepEqual(clusters, [undefined, undefined]);
   });
 
   it('should log the correct cluster count', () => {
@@ -973,13 +1000,13 @@ describe('DataChunks.addClusterFacet()', () => {
     d.load(chunks);
 
     // Define a facet function
-    d.addFacet('url', (bundle) => [bundle.url]);
+    d.addFacet('url', (bundle) => [bundle.url], 'some', 'never');
 
     // Add a cluster facet based on the 'url' facet
     const count = Math.floor(Math.log10(92));
     d.addClusterFacet('urlCluster', 'url', {
       count,
-    });
+    }, 'some', 'never');
 
     // Check if the count is correct
     assert.strictEqual(count, 1);
@@ -990,12 +1017,12 @@ describe('DataChunks.addClusterFacet()', () => {
     d.load(chunks);
 
     // Define a facet function
-    d.addFacet('url', (bundle) => [bundle.url]);
+    d.addFacet('url', (bundle) => [bundle.url], 'some', 'never');
 
     // Add a cluster facet based on the 'url' facet
     d.addClusterFacet('urlCluster', 'url', {
       count: Math.log10(d.facets.url.length),
-    });
+    }, 'some', 'never');
 
     const { facets } = d;
 


### PR DESCRIPTION


## Description
This PR adds check for empty returned value for facetMatch.
It also covers enabling filters for clusterFacet.

## Related Issue
#42 

## Motivation and Context
This came up as a requirement while enabling use of clusterFacet for URL facet

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
