### PR TITLE
fine tuning cassie cookie consent match to only button clicks

### DIFF
--- a/consent.js
+++ b/consent.js
@@ -43,7 +43,7 @@ const vendors = [
   },
   {
     vendor: 'cassie',
-    match: /#cassie/,
+    match: /button#cassie/,
     accept: /accept/,
     reject: /reject/,
   },

--- a/test/consent.test.js
+++ b/test/consent.test.js
@@ -32,7 +32,7 @@ describe('classifyConsent', () => {
   });
 
   it('should correctly identify the target action for Cassie consent forms', () => {
-    const cssSelector = '#cassie-accept-all-pre-banner';
+    const cssSelector = 'button#cassie-accept-all-pre-banner';
     const consent = classifyConsent(cssSelector);
     assert.strictEqual(consent.target, 'accept');
   });

--- a/test/consent.test.js
+++ b/test/consent.test.js
@@ -32,9 +32,15 @@ describe('classifyConsent', () => {
   });
 
   it('should correctly identify the target action for Cassie consent forms', () => {
-    const cssSelector = 'button#cassie-accept-all-pre-banner';
+    const cssSelector = 'dialog button#cassie-accept-all-pre-banner';
     const consent = classifyConsent(cssSelector);
     assert.strictEqual(consent.target, 'accept');
+  });
+
+  it('should not count non button clicks for Cassie consent forms', () => {
+    const cssSelector = 'dialog #cassie_accept_all_toggle_slider';
+    const consent = classifyConsent(cssSelector);
+    assert.strictEqual(consent, undefined);
   });
 
   it('should return undefined for a vendor without specific actions', () => {


### PR DESCRIPTION
Fine tuning how we match for Cassie cookie consent button clicks to be more specific

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
