### PR TITLE
fix derived facets

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -257,6 +257,7 @@ export class DataChunks {
   }
 
   resetFacets() {
+    this.filters = {};
     this.facetFns = {};
     this.facetCombiners = {};
   }

--- a/test/distiller.test.js
+++ b/test/distiller.test.js
@@ -929,6 +929,42 @@ describe('DataChunks.hasConversion', () => {
   });
 });
 
+describe('DataChunks.addHistogramFacet()', () => {
+  it('should create a histogram facet based on a base facet', () => {
+    const d = new DataChunks();
+    d.load(chunks);
+
+    d.addFacet('pathlength', (bundle) => bundle.url.length);
+
+    d.addHistogramFacet('pathlengthHistogram', 'pathlength', {
+      count: 10,
+      min: 0,
+      max: Infinity,
+      steps: 'linear',
+    });
+
+    const { facets } = d;
+
+    assert.equal(facets.pathlength.length, 31);
+    assert.equal(facets.pathlengthHistogram.length, 10);
+
+    // reset the facets and re-define them again
+    d.resetFacets();
+    d.addFacet('pathlength', (bundle) => bundle.url.length);
+    d.addHistogramFacet('pathlengthHistogram', 'pathlength', {
+      count: 10,
+      min: 0,
+      max: Infinity,
+      steps: 'linear',
+    });
+
+    const { facets: facets2 } = d;
+
+    assert.equal(facets2.pathlength.length, 31);
+    assert.equal(facets2.pathlengthHistogram.length, 10);
+  });
+});
+
 describe('DataChunks.addClusterFacet()', () => {
   it('should create clusters based on URL facet', () => {
     const d = new DataChunks();


### PR DESCRIPTION
The `addHistogramFacet` and `addClusterFacet` functions would run into issues if facets were reset, but existing filters stayed persisted. As filters are dependent on facets, resetting the filters should also reset the facets.


- **fix: reset filters during facet reset**
- **test(distiller): add test for histogram facet**
