### PR TITLE
Fix AI acquisition classification

### DIFF
--- a/acquisition.js
+++ b/acquisition.js
@@ -48,8 +48,9 @@ const vendorTypeLookup = {
   tiktok: 'paid',
   amazon: 'paid',
   direct: 'earned',
-  chatgpt: 'owned',
-  perplexity: 'owned',
+  // AI traffic is earned, not owned
+  chatgpt: 'earned',
+  perplexity: 'earned',
 };
 
 const categoryClassifications = [

--- a/test/acquisition.test.js
+++ b/test/acquisition.test.js
@@ -111,8 +111,8 @@ describe('classifyAcquisition', () => {
     { input: 'ctv', expected: 'paid:video:amazon' },
     { input: 'print', expected: 'owned:print' },
     { input: 'paid social', expected: 'paid:social', only: true },
-    { input: 'chatgpt.com', expected: 'owned:ai:chatgpt' },
-    { input: 'perplexity', expected: 'owned:ai:perplexity' },
+    { input: 'chatgpt.com', expected: 'earned:ai:chatgpt' },
+    { input: 'perplexity', expected: 'earned:ai:perplexity' },
   ];
 
   testCases


### PR DESCRIPTION
## Summary
- classify `chatgpt` and `perplexity` traffic as earned
- update acquisition tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68650bf7fdfc8333951ea7e6d13e19c1