### PR TITLE
Optimize filter lookup by using Set for large arrays and add comprehensive tests

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -635,6 +635,12 @@ export class DataChunks {
         const combiner = combiners[combinerprefence];
         const negator = negators[combinerprefence];
 
+        // Optimize lookup: use Set for O(1) lookup when actualValues is large (>= 5 items)
+        // For small arrays, .includes() is faster due to Set construction overhead
+        if (actualValues.length >= 5) {
+          const actualValuesSet = new Set(actualValues);
+          return desiredValues[combiner]((value) => negator(actualValuesSet.has(value)));
+        }
         return desiredValues[combiner]((value) => negator(actualValues.includes(value)));
       }));
     } catch (error) {

--- a/test/distiller.test.js
+++ b/test/distiller.test.js
@@ -821,6 +821,107 @@ describe('DataChunks', () => {
 
     assert.equal(d.filtered.length, 1);
   });
+
+  it('DataChunk.filter() with large array (Set optimization path)', () => {
+    // Test the Set optimization path for arrays with >= 5 items
+    const chunks1 = [
+      {
+        date: '2024-05-06',
+        rumBundles: [
+          {
+            id: 'one',
+            host: 'www.aem.live',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.aem.live/page1',
+            userAgent: 'desktop:windows',
+            weight: 100,
+            events: [{ checkpoint: 'top' }],
+          },
+          {
+            id: 'two',
+            host: 'www.aem.live',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.aem.live/page2',
+            userAgent: 'desktop:mac',
+            weight: 100,
+            events: [{ checkpoint: 'top' }],
+          },
+          {
+            id: 'three',
+            host: 'www.aem.live',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.aem.live/page3',
+            userAgent: 'mobile:ios',
+            weight: 100,
+            events: [{ checkpoint: 'top' }],
+          },
+          {
+            id: 'four',
+            host: 'www.aem.live',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.aem.live/page4',
+            userAgent: 'mobile:android',
+            weight: 100,
+            events: [{ checkpoint: 'top' }],
+          },
+          {
+            id: 'five',
+            host: 'www.aem.live',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.aem.live/page5',
+            userAgent: 'bot',
+            weight: 100,
+            events: [{ checkpoint: 'top' }],
+          },
+          {
+            id: 'six',
+            host: 'www.aem.live',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.aem.live/page6',
+            userAgent: 'tablet',
+            weight: 100,
+            events: [{ checkpoint: 'top' }],
+          },
+        ],
+      },
+    ];
+    const d = new DataChunks();
+    d.load(chunks1);
+
+    // Create a facet that returns an array with >= 5 items
+    d.addFacet('multivalue', (bundle) => [
+      'value1',
+      'value2',
+      'value3',
+      'value4',
+      'value5',
+      bundle.id, // Include bundle-specific value
+    ]);
+
+    // Filter where some bundles match
+    d.filter = {
+      multivalue: ['one', 'two'],
+    };
+    assert.equal(d.filtered.length, 2);
+
+    // Filter where no bundles match
+    d.filter = {
+      multivalue: ['nonexistent'],
+    };
+    assert.equal(d.filtered.length, 0);
+
+    // Filter where all bundles match (common values)
+    d.filter = {
+      multivalue: ['value1'],
+    };
+    assert.equal(d.filtered.length, 6);
+  });
 });
 
 describe('DataChunks.hasConversion', () => {


### PR DESCRIPTION
## Summary
- Improves performance of filtering logic in `distiller.js` by switching to a `Set` for lookups when the array has 5 or more items
- Maintains existing behavior using `.includes()` for smaller arrays to avoid overhead of `Set` construction
- Adds comprehensive tests to verify the filtering behavior for both small and large arrays, ensuring correctness of the optimization

## Changes

### Core Logic
- Added condition to check length of `actualValues`:
  - If `actualValues.length >= 5`, create a `Set` from `actualValues` for O(1) lookup
  - Otherwise, continue using `.includes()` for lookup
- This optimization targets the filter logic at line 638 (in DataChunks class) where `negator` and `combiner` functions are applied

### Tests
- Added new test suite covering the Set optimization branch where filtering is applied with arrays having >= 5 items
- Tests cover scenarios with matches, no matches, and all matches involving complex `rumBundles`
- Ensures correctness and guards against regressions for the new optimization

## Test plan
- [x] Verify existing tests pass to ensure no behavior regressions
- [x] Confirm new tests adequately cover optimized filter logic
- [ ] Benchmark filter operation with small and large arrays to confirm performance improvement

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ae8b9714-0f15-4b87-bca8-c22880f820b1
