### PR TITLE
Optimize group function by pre-allocating arrays to improve performance

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -750,7 +750,7 @@ export class DataChunks {
    * bundle will be skipped.
    * @param {groupByFn} groupByFn for each object, determine the group key
    * @returns {Object<string, Bundle[]>} grouped data, each key is a group
-   * and each vaule is an array of bundles
+   * and each value is an array of bundles
    */
   group(groupByFn) {
     this.groupedIn = groupBundlesOptimized(this.filtered, groupByFn);

--- a/distiller.js
+++ b/distiller.js
@@ -76,7 +76,7 @@ function aggregateFn(valueFn) {
  * Optimized grouping function using two-pass approach with pre-allocated arrays.
  * This eliminates the performance cost of dynamic array growth.
  * @param {Bundle[]} bundles - Array of bundles to group
- * @param {groupByFn} groupByFn - Function to determine group key(s) for each bundle
+ * @param {function(Bundle): (string|string[]|null)} groupByFn - Function to determine group key(s) for each bundle
  * @returns {Object<string, Bundle[]>} Grouped bundles
  */
 function groupBundlesOptimized(bundles, groupByFn) {

--- a/distiller.js
+++ b/distiller.js
@@ -72,21 +72,63 @@ function aggregateFn(valueFn) {
   };
 }
 
-function groupFn(groupByFn) {
-  return (acc, bundle) => {
+/**
+ * Optimized grouping function using two-pass approach with pre-allocated arrays.
+ * This eliminates the performance cost of dynamic array growth.
+ * @param {Bundle[]} bundles - Array of bundles to group
+ * @param {groupByFn} groupByFn - Function to determine group key(s) for each bundle
+ * @returns {Object<string, Bundle[]>} Grouped bundles
+ */
+function groupBundlesOptimized(bundles, groupByFn) {
+  // Pass 1: Count bundles per group to determine array sizes
+  const counts = {};
+
+  for (let i = 0; i < bundles.length; i += 1) {
+    const bundle = bundles[i];
     const key = groupByFn(bundle);
-    if (!key) return acc;
+    if (!key) continue; // eslint-disable-line no-continue
+
     if (Array.isArray(key)) {
-      key.forEach((k) => {
-        if (!acc[k]) acc[k] = [];
-        acc[k].push(bundle);
-      });
-      return acc;
+      for (let j = 0; j < key.length; j += 1) {
+        const k = key[j];
+        counts[k] = (counts[k] || 0) + 1;
+      }
+    } else {
+      counts[key] = (counts[key] || 0) + 1;
     }
-    if (!acc[key]) acc[key] = [];
-    acc[key].push(bundle);
-    return acc;
-  };
+  }
+
+  // Pass 2: Pre-allocate arrays and fill them
+  const result = {};
+  const indices = {};
+
+  // Pre-allocate all arrays
+  const keys = Object.keys(counts);
+  for (let i = 0; i < keys.length; i += 1) {
+    const k = keys[i];
+    result[k] = new Array(counts[k]);
+    indices[k] = 0;
+  }
+
+  // Fill arrays
+  for (let i = 0; i < bundles.length; i += 1) {
+    const bundle = bundles[i];
+    const key = groupByFn(bundle);
+    if (!key) continue; // eslint-disable-line no-continue
+
+    if (Array.isArray(key)) {
+      for (let j = 0; j < key.length; j += 1) {
+        const k = key[j];
+        result[k][indices[k]] = bundle;
+        indices[k] += 1;
+      }
+    } else {
+      result[key][indices[key]] = bundle;
+      indices[key] += 1;
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -711,7 +753,7 @@ export class DataChunks {
    * and each vaule is an array of bundles
    */
   group(groupByFn) {
-    this.groupedIn = this.filtered.reduce(groupFn(groupByFn), {});
+    this.groupedIn = groupBundlesOptimized(this.filtered, groupByFn);
     if (groupByFn.fillerFn) {
       // fill in the gaps, as sometimes there is no data for a group
       // so we need to add an empty array for that group
@@ -854,16 +896,17 @@ export class DataChunks {
           // so that we can show all values, not just the ones that do not match
           skipped.push(`${facetName}!`);
         }
-        const groupedByFacetIn = this
+        const groupedByFacetIn = groupBundlesOptimized(
           // we filter the bundles by all active filters,
           // except for the current facet (we want to see)
           // all values here.
-          .filterBundles(
+          this.filterBundles(
             this.bundles,
             this.filters,
             skipped,
-          )
-          .reduce(groupFn(facetValueFn), {});
+          ),
+          facetValueFn,
+        );
 
         // eslint-disable-next-line no-param-reassign
         accOuter[facetName] = Object.entries(groupedByFacetIn)


### PR DESCRIPTION
## Summary
- Replaces existing `groupFn` with an optimized `groupBundlesOptimized` function
- Implements a two-pass grouping approach:
  - First pass counts bundles per group for array size pre-allocation
  - Second pass fills pre-allocated arrays without dynamic resizing
- Improves efficiency by eliminating repeated array resizing during grouping
- Updates usages of the group function in `DataChunks` methods to use the optimized version

## Changes

### Core Functionality
- Removed old `groupFn` reducer function
- Added `groupBundlesOptimized`:
  - Accepts list of bundles and a grouping function
  - Handles both single and multiple group keys
  - Uses two-pass approach to pre-allocate arrays for groupings

### Integration
- Updated `group(groupByFn)` method in `DataChunks` class to use optimized grouping
- Modified filtering and grouping steps inside `DataChunks` to replace old reducer calls with `groupBundlesOptimized`

### Code Quality
- Added detailed JSDoc comment explaining optimization approach and parameters
- Maintained existing behavior for bundles without keys by continuing iteration silently

## Test plan
- Verified groupings produce identical results compared to previous implementation
- Tested grouping with single and multiple keys per bundle
- Checked performance improvement with larger bundle sets
- Confirmed no regressions in existing filters or grouping-dependent features

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b420fa55-6b8a-4e2f-a35c-5e96c7c64eb7