### PR TITLE
Optimize sorting in reduce loop for facet bundles

### DIFF
--- a/distiller.js
+++ b/distiller.js
@@ -994,10 +994,10 @@ export class DataChunks {
           .reduce((accInner, [facetValue, bundles]) => {
             accInner.push(bundles
               .reduce(f, new Facet(this, facetValue, facetName)));
-            // sort the entries by weight, descending
-            accInner.sort((left, right) => right.weight - left.weight);
             return accInner;
-          }, []);
+          }, [])
+          // sort the entries by weight, descending (once after reduce completes)
+          .sort((left, right) => right.weight - left.weight);
         return accOuter;
       }, {});
     return this.facetsIn;


### PR DESCRIPTION
## Summary
- Refactored sorting logic in `DataChunks` class's facet bundling
- Moved sorting outside inner reduce loop to execute once per accumulation
- Enhances performance by reducing redundant sorts during iteration

## Changes

### Core Logic
- In `distiller.js`, modified `.reduce()` handling facet bundles:
  - Removed `.sort()` call inside inner `.reduce()` iteration
  - Added a single `.sort()` after the reduction completes to sort bundles by descending weight

## Test plan
- [x] Verified existing tests pass without regressions
- [x] Confirmed sorting order remains correct after refactor
- [x] Validated performance improvement with sample data sets

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f0d88968-43ca-4b82-8270-3f5a5408c93f